### PR TITLE
Add NIS2 directive + nis2-controls OSS mapping library

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This list is intended for **compliance officers**, **risk managers**, **auditors
 - [ISO 27701](https://www.iso.org/standard/71670.html) - Privacy Information Management System standard (Annual audit).
 - [Microsoft SSPA](https://www.microsoft.com/en-us/trust-center/privacy/data-protection-requirements) - Microsoft's Supplier Security & Privacy Assurance (Annual audit).
 - [NIST AI RMF](https://www.nist.gov/itl/ai-risk-management-framework) - Risk management framework for AI governance (self-declarative).
+- [NIS2](https://digital-strategy.ec.europa.eu/en/policies/nis2-directive) - EU directive on cybersecurity risk-management and incident-reporting for essential and important entities (Annual evidence; first formal audits expected from 2027 in most member states).
 - [PIPEDA](https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/the-personal-information-protection-and-electronic-documents-act-pipeda/) - Personal Information Protection and Electronic Documents Act (self-declarative).
 - [SOC 1](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-1) - Reporting on internal financial controls (Annual audit).
 - [SOC 2](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2) - Service Organization Control reports (Annual audit).
@@ -115,6 +116,7 @@ This list is intended for **compliance officers**, **risk managers**, **auditors
 ### Risk & compliance management
 
 - [GRR Rapid Response](https://github.com/google/grr) - Open-source incident response framework by Google. ![Open Source](https://img.shields.io/badge/-Open%20Source-1a2029?logo=opensourceinitiative&logoColor=white&labelColor=00dc82)
+- [nis2-controls](https://github.com/saasfort/nis2-controls) - Machine-readable control library for NIS2 Art. 21(2) with crosswalks to ISO 27001, BSI IT-Grundschutz, CIS Controls v8, NIST CSF 2.0, DORA, and OWASP ASVS (MIT). ![Open Source](https://img.shields.io/badge/-Open%20Source-1a2029?logo=opensourceinitiative&logoColor=white&labelColor=00dc82)
 
 ### Security assessment
 


### PR DESCRIPTION
Two related additions, both fill genuine gaps in the current list:

**1. NIS2 directive — added under `Security, privacy & data protection`**

NIS2 (Directive (EU) 2022/2555) is the EU's cybersecurity risk-management + incident-reporting directive for essential and important entities. It's in active enforcement across most member states in 2026 and is not currently listed alongside GDPR / HIPAA / ISO 27001 in the security & data-protection section, which I expect is just because the list was built before NIS2 became operational. Same format as the existing entries:

```
- [NIS2](https://digital-strategy.ec.europa.eu/en/policies/nis2-directive) - EU directive on cybersecurity risk-management and incident-reporting for essential and important entities (Annual evidence; first formal audits expected from 2027 in most member states).
```

Link points at the official EU Digital Strategy page (canonical for the directive, equivalent to the gdpr.eu / pcisecuritystandards.org pattern other entries use).

**2. `nis2-controls` — added under `Risk & compliance management` (OSS library)**

Machine-readable JSON+YAML control library for NIS2 Article 21(2), with crosswalks to ISO 27001, BSI IT-Grundschutz, CIS Controls v8, NIST CSF 2.0, DORA, and OWASP ASVS. MIT. Slots next to the existing GRR (Google) OSS entry in the same section.

Disclosure: I maintain this library. Including it as an OSS reference because the awesome-compliance list currently has zero open-source NIS2-mapping entries, and this is a permissive, schema-defined dataset rather than a hosted product. Happy to drop it from the PR if it reads as self-promotion — the NIS2 standard add is the primary contribution.

Both inserts placed alphabetically / next to the existing sibling entry, no other changes to the README.